### PR TITLE
add default indexes to created_at and notifiable

### DIFF
--- a/database/migrations/create_notification_log_items_table.php
+++ b/database/migrations/create_notification_log_items_table.php
@@ -20,6 +20,9 @@ return new class extends Migration
             $table->text('exception_message')->nullable();
             $table->dateTime('confirmed_at')->nullable();
             $table->timestamps();
+            
+            $table->index(['notifiable_type', 'notifiable_id']);
+            $table->index(['created_at']);
         });
     }
 };


### PR DESCRIPTION
`latestFor()` calls always access the notifiable relationship and the created_at column.

Discussed at https://github.com/spatie/laravel-notification-log/discussions/7.