### PR TITLE
Added Get Config Variable

### DIFF
--- a/src/NotificationEventSubscriber.php
+++ b/src/NotificationEventSubscriber.php
@@ -52,7 +52,7 @@ class NotificationEventSubscriber
             return $notification->shouldLog($event);
         }
 
-        return true;
+        return config('notification-log.log_all_by_default') ?? true;
     }
 
     public function subscribe(): array


### PR DESCRIPTION
I noticed that the config variable `log_all_by_default` was not used anywhere. Is this the right place to add it?