### PR TITLE
Add option to query channels

### DIFF
--- a/src/Models/Concerns/HasNotifiableHistory.php
+++ b/src/Models/Concerns/HasNotifiableHistory.php
@@ -17,6 +17,7 @@ trait HasNotifiableHistory
         string|array $notificationTypes = null,
         Carbon $before = null,
         Carbon $after = null,
+        string|array $channel = null,
     ): ?NotificationLogItem {
         return $this->latestLoggedNotificationQuery(...func_get_args())->first();
     }
@@ -26,6 +27,7 @@ trait HasNotifiableHistory
         string|array $notificationTypes = null,
         Carbon $before = null,
         Carbon $after = null,
+        string|array $channel = null,
     ): Builder {
         $notificationLogClass = Config::notificationLogModelClass();
 

--- a/src/Models/NotificationLogItem.php
+++ b/src/Models/NotificationLogItem.php
@@ -55,6 +55,7 @@ class NotificationLogItem extends Model
         string|array $notificationType = null,
         Carbon $before = null,
         Carbon $after = null,
+        string|array $channel = null,
     ): ?NotificationLogItem {
         return self::latestForQuery(...func_get_args())->first();
     }
@@ -65,6 +66,7 @@ class NotificationLogItem extends Model
         string|array $notificationType = null,
         Carbon $before = null,
         Carbon $after = null,
+        string|array $channel = null,
     ): Builder {
         return self::query()
             ->where('notifiable_type', $notifiable->getMorphClass())
@@ -72,6 +74,9 @@ class NotificationLogItem extends Model
             ->when($fingerprint, fn (Builder $query) => $query->where('fingerprint', $fingerprint))
             ->when($notificationType, function (Builder $query) use ($notificationType) {
                 $query->whereIn('notification_type', Arr::wrap($notificationType));
+            })
+            ->when($channel, function (Builder $query) use ($channel) {
+                $query->whereIn('channel', Arr::wrap($channel));
             })
             ->when($before, function (Builder $query) use ($before) {
                 $query->where('created_at', '<', $before->toDateTimeString());

--- a/src/Support/NotificationHistoryQueryBuilder.php
+++ b/src/Support/NotificationHistoryQueryBuilder.php
@@ -26,6 +26,14 @@ class NotificationHistoryQueryBuilder
             );
     }
 
+    public function onChannel(string $channel): static
+    {
+        $this->query
+            ->where('channel', $channel);
+
+        return $this;
+    }
+
     public function inThePastMinutes(int $numberOfMinutes): bool
     {
         $query = $this->query

--- a/tests/Models/Concerns/HasHistoryTest/WasSentToTest.php
+++ b/tests/Models/Concerns/HasHistoryTest/WasSentToTest.php
@@ -125,6 +125,33 @@ it('can find a sent notification while ignoring the fingerprint', function (
     [null],
 ]);
 
+
+it('can find a sent notification with the same channel', function (
+    ?string $channel,
+    bool $expectedResult,
+) {
+    NotificationLogItem::factory()
+        ->forNotifiable($this->notifiable)
+        ->create([
+            'channel' => $channel,
+            'notification_type' => HasHistoryNotification::class,
+            'created_at' => now()->subMinutes(30),
+        ]);
+
+    $hasHistoryCalls = function ($notifiable, $channel) {
+        return $this
+            ->wasSentTo($notifiable)
+            ->onChannel($channel)
+            ->inThePastMinutes(60);
+    };
+
+    expect(executeInNotification($hasHistoryCalls, $this->notifiable))
+        ->toBe($expectedResult);
+})->with([
+    ['mail', true],
+    ['other-channel', false],
+]);
+
 function executeInNotification(Closure $closure, User $notifiable): bool
 {
     $closure = Closure::bind($closure, new HasHistoryNotification());

--- a/tests/Models/NotificationLogItemTest.php
+++ b/tests/Models/NotificationLogItemTest.php
@@ -77,6 +77,34 @@ it('can find the latest sent notification for fingerprint', function () {
         ->toBeNull();
 });
 
+
+it('can find the latest sent notification for channel', function () {
+    $firstChannel1 = NotificationLogItem::factory()->forNotifiable($this->user)->create([
+        'channel' => 'channel-1',
+    ]);
+
+    $secondChannel1 = NotificationLogItem::factory()->forNotifiable($this->user)->create([
+        'channel' => 'channel-1',
+    ]);
+
+    $firstChannel2 = NotificationLogItem::factory()->forNotifiable($this->user)->create([
+        'channel' => 'channel-2',
+    ]);
+
+    $secondChannel2 = NotificationLogItem::factory()->forNotifiable($this->user)->create([
+        'channel' => 'channel-2',
+    ]);
+
+    expect(NotificationLogItem::latestFor($this->user, channel: 'channel-1'))
+        ->toBeModel($secondChannel1);
+
+    expect(NotificationLogItem::latestFor($this->user, channel: 'channel-2'))
+        ->toBeModel($secondChannel2);
+
+    expect(NotificationLogItem::latestFor($this->user, channel: 'channel-3'))
+        ->toBeNull();
+});
+
 it('can find the latest notification in a certain period', function () {
     NotificationLogItem::factory()
         ->forNotifiable($this->user)

--- a/tests/TestSupport/Notifications/HasHistoryNotification.php
+++ b/tests/TestSupport/Notifications/HasHistoryNotification.php
@@ -3,6 +3,7 @@
 namespace Spatie\NotificationLog\Tests\TestSupport\Notifications;
 
 use Closure;
+use Illuminate\Support\Arr;
 use Spatie\NotificationLog\Models\Concerns\HasHistory;
 
 class HasHistoryNotification extends TestNotification
@@ -18,7 +19,10 @@ class HasHistoryNotification extends TestNotification
 
     public function historyTest($notifiable): bool
     {
-        return (self::$historyTestCallable)($notifiable);
+        return app()->call(self::$historyTestCallable, [
+            'notifiable' => $notifiable,
+            'channel' => Arr::first($this->via($notifiable)),
+        ]);
     }
 
     public function fingerprint()


### PR DESCRIPTION
This PR adds options to create queries that respect the notification channel. This is especially useful in combination with `shouldSend()` to prevent every channel after the first being ignored and fixes #22:

Example:

```php
public function shouldSend($notifiable, $channel): bool
{
    return $this
        ->wasNotSentTo($notifiable, withSameFingerprint: true)
        ->onChannel($channel)
        ->inThePastMinutes(30);
}
```