### PR TITLE
Update docs to add missing event parameter

### DIFF
--- a/docs/basic-usage/adding-extra-info-to-your-notification.md
+++ b/docs/basic-usage/adding-extra-info-to-your-notification.md
@@ -8,10 +8,11 @@ The `notification_log_items` table has a JSON column called `extra` that allows 
 To fill up the `extra` column, add a function named `logExtra` to your notification and let it return an array that should be stored in the `extra` column when the notification gets logged.
 
 ```php
+use Illuminate\Notifications\Events\NotificationSending;
+
 // in a notification
-public function logExtra(): array
+public function logExtra(NotificationSending $event): array
 {
     return ['extraKey' => 'extraValue'];
 }
 ```
-


### PR DESCRIPTION
Hi, 

Quick PR to update the docs. The `logExtra()` method in the provided example was missing the **NotificationSending** event parameter.