### PR TITLE
Remove unused exception_message db column

### DIFF
--- a/database/migrations/create_notification_log_items_table.php
+++ b/database/migrations/create_notification_log_items_table.php
@@ -17,7 +17,6 @@ return new class extends Migration
             $table->string('fingerprint')->nullable();
             $table->json('extra')->nullable();
             $table->json('anonymous_notifiable_properties')->nullable();
-            $table->text('exception_message')->nullable();
             $table->dateTime('confirmed_at')->nullable();
             $table->timestamps();
 


### PR DESCRIPTION
Removes the unused exception_message database column in migration file as reported in issue https://github.com/spatie/laravel-notification-log/issues/29.