### PR TITLE
Remove unnecessary method call in HasHistory

### DIFF
--- a/src/Models/Concerns/HasHistory.php
+++ b/src/Models/Concerns/HasHistory.php
@@ -12,8 +12,6 @@ trait HasHistory
     {
         $this->ensureNotifiableIsModel($notifiable);
 
-        $notifiable->latestLoggedNotification();
-
         return new NotificationHistoryQueryBuilder(
             $this,
             $notifiable,


### PR DESCRIPTION
I can't see this method call has any effect.