### PR TITLE
Add history builder inThePast() method

### DIFF
--- a/src/Support/NotificationHistoryQueryBuilder.php
+++ b/src/Support/NotificationHistoryQueryBuilder.php
@@ -34,10 +34,12 @@ class NotificationHistoryQueryBuilder
         return $this;
     }
 
-    public function inThePastMinutes(int $numberOfMinutes): bool
+    public function inThePastMinutes(?int $numberOfMinutes): bool
     {
         $query = $this->query
-            ->where('created_at', '>=', now()->subMinutes($numberOfMinutes))
+            ->when($numberOfMinutes !== null, function (Builder $query) use ($numberOfMinutes) {
+                $query->where('created_at', '>=', now()->subMinutes($numberOfMinutes));
+            })
             ->when($this->withSameFingerprint, function (Builder $query) {
                 $action = Config::convertEventToModelAction();
 
@@ -56,6 +58,11 @@ class NotificationHistoryQueryBuilder
         return $this->shouldExist
             ? $query->exists()
             : $query->doesntExist();
+    }
+
+    public function inThePast(): bool
+    {
+        return $this->inThePastMinutes(null);
     }
 
     public function query(): Builder

--- a/tests/Models/Concerns/HasHistoryTest/WasNotSentToTest.php
+++ b/tests/Models/Concerns/HasHistoryTest/WasNotSentToTest.php
@@ -125,6 +125,32 @@ it('will not find a sent notification while ignoring the fingerprint', function 
     [null],
 ]);
 
+it('can determine if it was not sent in the past', function (
+    bool $created,
+    bool $expectedResult,
+) {
+    if ($created) {
+        NotificationLogItem::factory()
+            ->forNotifiable($this->notifiable)
+            ->create([
+                'notification_type' => HasHistoryNotification::class,
+                'created_at' => now(),
+            ]);
+    }
+
+    $hasHistoryCalls = function ($notifiable) {
+        return $this
+            ->wasNotSentTo($notifiable)
+            ->inThePast();
+    };
+
+    expect(executeClosureInNotification($hasHistoryCalls, $this->notifiable))
+        ->toBe($expectedResult);
+})->with([
+    [true, false],
+    [false, true],
+]);
+
 function executeClosureInNotification(Closure $closure, User $notifiable): bool
 {
     $closure = Closure::bind($closure, new HasHistoryNotification());

--- a/tests/Models/Concerns/HasHistoryTest/WasSentToTest.php
+++ b/tests/Models/Concerns/HasHistoryTest/WasSentToTest.php
@@ -151,6 +151,32 @@ it('can find a sent notification with the same channel', function (
     ['other-channel', false],
 ]);
 
+it('can determine if it was sent in the past', function (
+    bool $created,
+    bool $expectedResult,
+) {
+    if ($created) {
+        NotificationLogItem::factory()
+            ->forNotifiable($this->notifiable)
+            ->create([
+                'notification_type' => HasHistoryNotification::class,
+                'created_at' => now(),
+            ]);
+    }
+
+    $hasHistoryCalls = function ($notifiable) {
+        return $this
+            ->wasSentTo($notifiable)
+            ->inThePast();
+    };
+
+    expect(executeInNotification($hasHistoryCalls, $this->notifiable))
+        ->toBe($expectedResult);
+})->with([
+    [true, true],
+    [false, false],
+]);
+
 function executeInNotification(Closure $closure, User $notifiable): bool
 {
     $closure = Closure::bind($closure, new HasHistoryNotification());


### PR DESCRIPTION
I wanted to check if a notification had been sent at all but couldn't find a way to do it. So I added a inThePast() method without the minutes parameter allowing this syntax:
``` 
$notification->wasSentTo($user)->inThePast();
```

Let me know if there's a better way to achieve this that I missed.