### PR TITLE
Don't put falsey log item in map

### DIFF
--- a/src/NotificationEventSubscriber.php
+++ b/src/NotificationEventSubscriber.php
@@ -31,8 +31,6 @@ class NotificationEventSubscriber
         if ($logItem) {
             self::$sentNotifications[$event->notification] = $logItem;
         }
-
-        self::$sentNotifications[$event->notification] = $logItem;
     }
 
     public function handleNotificationSent(NotificationSent $event): void


### PR DESCRIPTION
Fixes #37

I was trying to figure out a simple way to write another test for this, but I'm not really sure how to do it - and I don't see any other tests that check the contents of the `WeakMap`.