### PR TITLE
Fix incorrect method name wasAlreadySentTo → wasSentTo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ In a view, you could write this:
 </ul>
 ```
 
-The package also contains handy methods that allow you to make decisions based on the notifications sent. Here's an example, where we use the `wasAlreadySentTo` method provided by the package in a `shouldSent` method of a notification.
+The package also contains handy methods that allow you to make decisions based on the notifications sent. Here's an example, where we use the `wasSentTo` method provided by the package in a `shouldSend` method of a notification.
 
 ```php
 // in a notification
@@ -42,7 +42,7 @@ The package also contains handy methods that allow you to make decisions based o
 public function shouldSend($notifiable)
 {
       return ! $this
-        ->wasAlreadySentTo($notifiable)
+        ->wasSentTo($notifiable)
         ->inThePastMinutes(60);
 }
 ```

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -22,7 +22,7 @@ In a view you could write this:
 </ul>
 ```
 
-The package also contains handy methods that allow you to make decisions based on the notifications sent. Here's an example, where we use the `wasAlreadySentTo` method provided by the package in the `shouldSend` method of a notification.
+The package also contains handy methods that allow you to make decisions based on the notifications sent. Here's an example, where we use the `wasSentTo` method provided by the package in the `shouldSend` method of a notification.
 
 ```php
 use Spatie\NotificationLog\Models\Concerns\HasHistory;


### PR DESCRIPTION
The README and introduction docs reference `wasAlreadySentTo`, but the actual method provided by the package is `wasSentTo`. This updates both files to use the correct method name. Additionally, misspelled `shouldSent` in README was fixed.